### PR TITLE
Allow pre-commit to run SBT commands via a socket connection

### DIFF
--- a/pre_commit/languages/sbt.py
+++ b/pre_commit/languages/sbt.py
@@ -104,3 +104,35 @@ def connect_to_sbt_server(socket_file: Path) -> socket.socket:
     sbt_connection = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
     sbt_connection.connect(str(socket_file))
     return sbt_connection
+
+
+def create_exec_request(command_id: int, sbt_command: str) -> str:
+    """
+    Create an exec request for SBT server
+    :param command_id: A unique ID for the task
+    :param sbt_command: The command to be run in SBT
+    :return: A request which (when sent to SBT server) will invoke the
+    provided command
+    """
+    # TODO: do not reload project (experimentation needed)
+    rpc_body = _body(command_id, f'reload;{sbt_command}')
+    bsp_header = _header(len(rpc_body) + 2)
+    return bsp_header + '\r\n' + rpc_body + '\r\n'
+
+
+def _header(length: int) -> str:
+    return f"""Content-Type: application/vscode-jsonrpc; charset=utf-8\r\n"""\
+           f"""Content-Length: {length}\r\n"""
+
+
+def _body(command_id: int, sbt_command: str) -> str:
+    return json.dumps(
+        {
+            'jsonrpc': '2.0',
+            'id': command_id,
+            'method': 'sbt/exec',
+            'params': {
+                'commandLine': sbt_command,
+            },
+        },
+    )

--- a/pre_commit/languages/sbt.py
+++ b/pre_commit/languages/sbt.py
@@ -24,10 +24,7 @@ def run_hook(
         color: bool,
 ) -> tuple[int, bytes]:
     if is_server_running(Path('.')):
-        with open(port_file_path(Path('.')), encoding='UTF-8') as port_file, \
-                connect_to_sbt_server(connection_details(port_file)) as _:
-            # TODO: Improve impl to connect to run commands via SBT server
-            return run_sbt_hook_via_commandline(hook, file_args, color)
+        return run_sbt_hook_via_lsp(hook, file_args, color)
     else:
         return run_sbt_hook_via_commandline(hook, file_args, color)
 
@@ -54,6 +51,17 @@ def run_sbt_hook_via_commandline(
 
 def _quote(s: str) -> str:
     return f"\"{s}\""
+
+
+def run_sbt_hook_via_lsp(
+        hook: Hook,
+        file_args: Sequence[str],
+        color: bool,
+) -> tuple[int, bytes]:
+    with open(port_file_path(Path('.')), encoding='UTF-8') as port_file, \
+            connect_to_sbt_server(connection_details(port_file)) as _:
+        # TODO: Improve impl to connect to run commands via SBT server
+        return run_sbt_hook_via_commandline(hook, file_args, color)
 
 
 def is_server_running(root_dir: Path) -> bool:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,5 +2,6 @@ covdefaults>=2.2
 coverage
 distlib
 pytest
+pytest-asyncio
 pytest-env
 re-assert

--- a/testing/resources/sbt_repo_with_sleep_command/build.sbt
+++ b/testing/resources/sbt_repo_with_sleep_command/build.sbt
@@ -1,0 +1,6 @@
+import SleepCommand._
+
+lazy val root = (project in file("."))
+  .settings(
+    commands ++= Seq(sleepCommand)
+  )

--- a/testing/resources/sbt_repo_with_sleep_command/project/SleepCommand.scala
+++ b/testing/resources/sbt_repo_with_sleep_command/project/SleepCommand.scala
@@ -1,0 +1,9 @@
+import sbt.Command
+
+object SleepCommand {
+  def sleepCommand = Command.single("sleep") { (state, arg) =>
+    val waitSec = Integer.parseInt(arg)
+    Thread.sleep(waitSec * 1000L)
+    state
+  }
+}

--- a/testing/sbt_test_utils.py
+++ b/testing/sbt_test_utils.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import asyncio
+import subprocess
+from asyncio.subprocess import Process
+from pathlib import Path
+
+_TIMEOUT = 30
+
+
+async def start_sbt_server(
+        root_dir: Path,
+        shutdown_timeout: int = _TIMEOUT,
+) -> Process:
+    process = await asyncio.create_subprocess_shell(
+        'sbt',
+        cwd=root_dir,
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        shell=True,
+    )
+    await asyncio.wait_for(
+        _wait_until_server_started(root_dir),
+        timeout=shutdown_timeout,
+    )
+    return process
+
+
+async def shutdown_sbt_server(
+        proc: Process,
+        *,
+        timeout: int = _TIMEOUT,
+) -> None:
+    try:
+        await asyncio.wait_for(
+            proc.communicate(b'shutdown\n'), timeout=timeout,
+        )
+    except asyncio.TimeoutError:
+        proc.kill()
+
+
+async def _wait_until_server_started(root_dir: Path) -> None:
+    while not _is_server_running(root_dir):
+        await asyncio.sleep(1)
+
+
+_ACTIVE_JSON_PATH = 'project/target/active.json'
+
+
+def _port_file_path(root_dir: Path) -> Path:
+    return root_dir.joinpath(_ACTIVE_JSON_PATH)
+
+
+def _is_server_running(root_dir: Path) -> bool:
+    return _port_file_path(root_dir).exists()

--- a/testing/sbt_test_utils.py
+++ b/testing/sbt_test_utils.py
@@ -5,6 +5,8 @@ import subprocess
 from asyncio.subprocess import Process
 from pathlib import Path
 
+from pre_commit.languages.sbt import is_server_running
+
 _TIMEOUT = 30
 
 
@@ -40,16 +42,5 @@ async def shutdown_sbt_server(
 
 
 async def _wait_until_server_started(root_dir: Path) -> None:
-    while not _is_server_running(root_dir):
+    while not is_server_running(root_dir):
         await asyncio.sleep(1)
-
-
-_ACTIVE_JSON_PATH = 'project/target/active.json'
-
-
-def _port_file_path(root_dir: Path) -> Path:
-    return root_dir.joinpath(_ACTIVE_JSON_PATH)
-
-
-def _is_server_running(root_dir: Path) -> bool:
-    return _port_file_path(root_dir).exists()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -257,10 +257,18 @@ def set_git_templatedir(tmpdir_factory):
         yield
 
 
-@pytest_asyncio.fixture(params=[False, True])
-async def sbt_project_with_touch_command(tempdir_factory, request):
+@pytest_asyncio.fixture
+async def sbt_project_with_touch_command_no_server(tempdir_factory):
     project_repo = make_repo(tempdir_factory, 'sbt_repo_with_touch_command')
-    project_root = Path(project_repo)
+    return Path(project_repo)
+
+
+@pytest_asyncio.fixture(params=[False, True])
+async def sbt_project_with_touch_command(
+        sbt_project_with_touch_command_no_server,
+        request,
+):
+    project_root = sbt_project_with_touch_command_no_server
     if request.param:  # start an sbt server
         server_process = await start_sbt_server(project_root)
         yield project_root

--- a/tests/languages/sbt_test.py
+++ b/tests/languages/sbt_test.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
+import asyncio
 import json
 import socket
-from asyncio import open_unix_connection
 from asyncio import StreamReader
 from itertools import product
 from pathlib import Path
@@ -17,13 +17,14 @@ from pre_commit.hook import Hook
 from pre_commit.languages import sbt
 from pre_commit.languages.sbt import connect_to_sbt_server
 from pre_commit.languages.sbt import connection_details
-from pre_commit.languages.sbt import create_exec_request
 from pre_commit.languages.sbt import get_next_message
 from pre_commit.languages.sbt import is_server_running
 from pre_commit.languages.sbt import JsonType
 from pre_commit.languages.sbt import port_file_path
 from pre_commit.languages.sbt import read_until_complete_message
 from pre_commit.languages.sbt import return_code
+from pre_commit.languages.sbt import run_via_lsp
+from testing.fixtures import make_repo
 from testing.sbt_test_utils import shutdown_sbt_server
 from testing.sbt_test_utils import start_sbt_server
 from testing.util import cwd
@@ -92,7 +93,7 @@ def test_connect_to_sbt_server(tmp_path: Path) -> None:
     """connect_to_sbt_server, should connect to an existing socket"""
     # arrange & act
     sock_file = tmp_path.joinpath('socket.sock')
-    with _create_listening_socket(sock_file) as sock_listen,\
+    with _create_listening_socket(sock_file) as sock_listen, \
             connect_to_sbt_server(sock_file) as sock_under_test:
         expected = 'sample text'
         conn, _ = sock_listen.accept()
@@ -186,27 +187,62 @@ async def test_get_next_message() -> None:
 
 @skipif_cant_run_sbt
 @pytest.mark.asyncio
-async def test_valid_lsp_request(
+async def test_run_via_lsp(
         sbt_project_with_touch_command_and_socket: tuple[Path, SocketType],
 ) -> None:
     """A valid request can be sent to SBT server, and we can determine when
     the SBT command has complete"""
     # arrange
     project_path, sbt_conn = sbt_project_with_touch_command_and_socket
-    task_id = 10
     file_to_create = 'sample_file.txt'
 
-    reader, writer = await open_unix_connection(sock=sbt_conn)
-
-    # act
-    rpc = create_exec_request(task_id, rf"""touch "{file_to_create}" """)
-    writer.write(rpc.encode('UTF-8'))
-    _rc, _ = await read_until_complete_message(reader, task_id)
+    ret, _ = await run_via_lsp(
+        f'touch {file_to_create}',
+        sbt_conn,
+    )
 
     # assert
     expected_file = project_path.joinpath(file_to_create)
     assert expected_file.exists()
-    assert _rc == 0
+    assert ret == 0
+
+
+@skipif_cant_run_sbt
+@pytest.mark.asyncio
+async def test_run_via_lsp_invalid_command(
+        sbt_project_with_socket: tuple[Path, SocketType],
+) -> None:
+    """A valid request can be sent to SBT server and we can determine when the
+    SBT command has complete"""
+    # arrange
+    project_path, sbt_conn = sbt_project_with_socket
+
+    ret, _ = await run_via_lsp(
+        'some non-existent command',
+        sbt_conn,
+    )
+
+    # assert
+    assert ret != 0
+
+
+@skipif_cant_run_sbt
+@pytest.mark.asyncio
+async def test_run_via_lsp_timeout(
+        sbt_project_with_sleep_command_and_socket: tuple[Path, SocketType],
+) -> None:
+    """A valid request can be sent to SBT server and we can determine when the
+    SBT command has complete"""
+    # arrange
+    project_path, sbt_conn = sbt_project_with_sleep_command_and_socket
+
+    # act & assert
+    with pytest.raises(asyncio.TimeoutError):
+        await run_via_lsp(
+            'sleep 10',
+            sbt_conn,
+            timeout=1,
+        )
 
 
 @skipif_cant_run_sbt
@@ -241,13 +277,11 @@ def test_sbt_hook(
         ret, out = sbt.run_hook(hook, files, False)
 
     # assert
-    output = out.decode('UTF-8')
     assert ret == 0
     for file in args + files:
         unquoted_file = _unquote(file)
         expected_file = project_root.joinpath(unquoted_file).absolute()
         assert expected_file.exists()
-        assert f'Creating file: {expected_file}' in output
 
 
 def _unquote(s: str) -> str:
@@ -286,6 +320,18 @@ async def sbt_project_with_server(
     await shutdown_sbt_server(server_process)
 
 
+@pytest_asyncio.fixture
+async def sbt_project_with_socket(
+        sbt_project_with_server: Path,
+) -> AsyncGenerator[tuple[Path, SocketType], None]:
+    project_repo = sbt_project_with_server
+    server_process = await start_sbt_server(project_repo)
+    with open(port_file_path(project_repo), encoding='UTF-8') as port_file, \
+            connect_to_sbt_server(connection_details(port_file)) as conn:
+        yield project_repo, conn
+        await shutdown_sbt_server(server_process)
+
+
 @pytest.fixture
 def sbt_project_without_server(
         tmp_path: Path,
@@ -294,12 +340,25 @@ def sbt_project_without_server(
 
 
 @pytest_asyncio.fixture
+async def sbt_project_with_sleep_command_and_socket(
+        tempdir_factory: Path,
+) -> AsyncGenerator[tuple[Path, SocketType], None]:
+    project_repo = make_repo(tempdir_factory, 'sbt_repo_with_sleep_command')
+    project_repo = Path(project_repo)
+    server_process = await start_sbt_server(project_repo)
+    with open(port_file_path(project_repo), encoding='UTF-8') as port_file, \
+            connect_to_sbt_server(connection_details(port_file)) as conn:
+        yield project_repo, conn
+        await shutdown_sbt_server(server_process)
+
+
+@pytest_asyncio.fixture
 async def sbt_project_with_touch_command_and_socket(
         sbt_project_with_touch_command_no_server: Path,
 ) -> AsyncGenerator[tuple[Path, SocketType], None]:
     project_root = sbt_project_with_touch_command_no_server
     server_process = await start_sbt_server(project_root)
-    with open(port_file_path(project_root), encoding='UTF-8') as port_file,\
+    with open(port_file_path(project_root), encoding='UTF-8') as port_file, \
             connect_to_sbt_server(connection_details(port_file)) as conn:
         yield project_root, conn
         await shutdown_sbt_server(server_process)

--- a/tests/languages/sbt_test.py
+++ b/tests/languages/sbt_test.py
@@ -3,13 +3,61 @@ from __future__ import annotations
 from itertools import product
 from pathlib import Path
 from typing import Any
+from typing import AsyncGenerator
 
 import pytest
+import pytest_asyncio
 
 from pre_commit.hook import Hook
 from pre_commit.languages import sbt
+from pre_commit.languages.sbt import is_server_running
+from pre_commit.languages.sbt import port_file_path
+from testing.sbt_test_utils import shutdown_sbt_server
+from testing.sbt_test_utils import start_sbt_server
 from testing.util import cwd
 from testing.util import skipif_cant_run_sbt
+
+
+@skipif_cant_run_sbt
+def test_active_json_is_file(sbt_project_with_server: Path) -> None:
+    """The port file of a running sbt server can be found"""
+
+    # act
+    port_file = port_file_path(sbt_project_with_server)
+
+    # assert
+    assert port_file.exists()
+
+
+def test_active_json_is_not_file(sbt_project_without_server: Path) -> None:
+    """The port file is not present if there is no running sbt server"""
+
+    # act
+    port_file = port_file_path(sbt_project_without_server)
+
+    # assert
+    assert not port_file.exists()
+
+
+@skipif_cant_run_sbt
+def test_is_server_running_true(sbt_project_with_server: Path) -> None:
+    """is_server_running should return true if SBT server is running"""
+
+    # act
+    actual = is_server_running(sbt_project_with_server)
+
+    # assert
+    assert actual is True
+
+
+def test_is_server_running_false(sbt_project_without_server: Path) -> None:
+    """is_server_running should return false if SBT server is not running"""
+
+    # act
+    actual = is_server_running(sbt_project_without_server)
+
+    # assert
+    assert actual is False
 
 
 @skipif_cant_run_sbt
@@ -61,3 +109,19 @@ def _create_hook(**kwargs: Any) -> Hook:
     default_values = {field: None for field in Hook._fields}
     actual_values = {**default_values, **kwargs}
     return Hook(**actual_values)  # type: ignore
+
+
+@pytest_asyncio.fixture
+async def sbt_project_with_server(
+        tmp_path: Path,
+) -> AsyncGenerator[Path, None]:
+    server_process = await start_sbt_server(tmp_path)
+    yield tmp_path
+    await shutdown_sbt_server(server_process)
+
+
+@pytest.fixture
+def sbt_project_without_server(
+        tmp_path: Path,
+) -> Path:
+    return tmp_path

--- a/tests/repository_test.py
+++ b/tests/repository_test.py
@@ -2,13 +2,11 @@ from __future__ import annotations
 
 import os.path
 import shutil
-from pathlib import Path
 from typing import Any
 from unittest import mock
 
 import cfgv
 import pytest
-import pytest_asyncio
 import re_assert
 
 import pre_commit.constants as C
@@ -32,8 +30,6 @@ from pre_commit.util import cmd_output_b
 from testing.fixtures import make_config_from_repo
 from testing.fixtures import make_repo
 from testing.fixtures import modify_manifest
-from testing.sbt_test_utils import shutdown_sbt_server
-from testing.sbt_test_utils import start_sbt_server
 from testing.util import cwd
 from testing.util import get_resource_path
 from testing.util import skipif_cant_run_coursier
@@ -1155,18 +1151,6 @@ def test_local_lua_additional_dependencies(store):
     ret, out = _hook_run(hook, (), color=False)
     assert b'Luacheck' in out
     assert ret == 0
-
-
-@pytest_asyncio.fixture(params=[False, True])
-async def sbt_project_with_touch_command(tempdir_factory, request):
-    project_repo = make_repo(tempdir_factory, 'sbt_repo_with_touch_command')
-    project_root = Path(project_repo)
-    if request.param:  # start an sbt server
-        server_process = await start_sbt_server(project_root)
-        yield project_root
-        await shutdown_sbt_server(server_process)
-    else:  # don't start an sbt server
-        yield project_root
 
 
 @skipif_cant_run_sbt

--- a/tests/repository_test.py
+++ b/tests/repository_test.py
@@ -2,11 +2,13 @@ from __future__ import annotations
 
 import os.path
 import shutil
+from pathlib import Path
 from typing import Any
 from unittest import mock
 
 import cfgv
 import pytest
+import pytest_asyncio
 import re_assert
 
 import pre_commit.constants as C
@@ -30,6 +32,8 @@ from pre_commit.util import cmd_output_b
 from testing.fixtures import make_config_from_repo
 from testing.fixtures import make_repo
 from testing.fixtures import modify_manifest
+from testing.sbt_test_utils import shutdown_sbt_server
+from testing.sbt_test_utils import start_sbt_server
 from testing.util import cwd
 from testing.util import get_resource_path
 from testing.util import skipif_cant_run_coursier
@@ -1151,6 +1155,18 @@ def test_local_lua_additional_dependencies(store):
     ret, out = _hook_run(hook, (), color=False)
     assert b'Luacheck' in out
     assert ret == 0
+
+
+@pytest_asyncio.fixture(params=[False, True])
+async def sbt_project_with_touch_command(tempdir_factory, request):
+    project_repo = make_repo(tempdir_factory, 'sbt_repo_with_touch_command')
+    project_root = Path(project_repo)
+    if request.param:  # start an sbt server
+        server_process = await start_sbt_server(project_root)
+        yield project_root
+        await shutdown_sbt_server(server_process)
+    else:  # don't start an sbt server
+        yield project_root
 
 
 @skipif_cant_run_sbt

--- a/tests/repository_test.py
+++ b/tests/repository_test.py
@@ -1174,17 +1174,12 @@ def test_sbt_hook(
         )
 
     # assert
-    output = out.decode('UTF-8')
     assert ret == 0
     file1 = project_root.joinpath('file1.txt').absolute()
     assert file1.exists()
-    assert f'Creating file: {file1}' in output
     file2 = project_root.joinpath('file2 with space.txt').absolute()
     assert file2.exists()
-    assert f'Creating file: {file2}' in output
     file3 = project_root.joinpath('file3.txt').absolute()
     assert file3.exists()
-    assert f'Creating file: {file3}' in output
     file4 = project_root.joinpath('file4 with space.txt').absolute()
     assert file4.exists()
-    assert f'Creating file: {file4}' in output


### PR DESCRIPTION
Connects to SBT server and runs commands via a socket connection.

This pull request:
 - Builds upon the previous pull request (which added SBT as a 0th class language), by connecting to SBT server via a socket connection. This avoids JVM start up time.
 - Commands will only be run via the network interface if it is available. If not available commands are run via the shell as introduced by the first pull request.

TODO:
 - [ ] ensure that the first pull request works correctly and has been merged.

Future improvements:
 - Only utilise the the "reload" command when needed (currently located in the `create_exec_request` function). The `reload` command causes the project's plugins, settings, and project definitions to be reloaded causing hooks to have an unnecessary overhead. The "reload" command should therefore only be invoked when necessary. (NB: iirc, this can just be removed and SBT, when running a command via the network interface will reload the project as needed - however this needs to be formalised via unit/integration tests).
 - Investigate edge cases, which involve a command being aborted before completion.
 - Add support/test on a Windows based machine (I suspect this may "just work" as implemented in this PR)